### PR TITLE
Fix issue where create-frontend-dockerfile is not honoring dist-folder

### DIFF
--- a/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
+++ b/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
@@ -60,7 +60,7 @@ spec:
     - name: dist-folder
       type: string
       description: directory where the app.info.json will be written
-      default: ""
+      default: "dist"
   workspaces:
     - name: source
       description: workspace where the code is stored
@@ -84,7 +84,7 @@ spec:
 
         cp Dockerfile $source_path
         cp Caddyfile $source_path
-        cp -r dist/ $source_path
+        cp -r $(params.dist-folder)/ $source_path
       env:
         - name: COMPONENT
           value: $(params.component)


### PR DESCRIPTION
Originally discovered this while migrating the `insights-chrome` to Konflux repo here: https://github.com/RedHatInsights/insights-chrome/pull/2957

We have `dist` hard-coded in create-frontend-dockerfile. This causes issues when repos use another directory (such as insights-chrome having `build`). We should honor the `dist-folder` param to correct this issue.

For now I've just duplicated these tasks in our pipelines. Once merged I will update to pull them from here.