### PR TITLE
tasks/create-frontend-dockerfile: don't create nested sources

### DIFF
--- a/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
+++ b/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
@@ -81,8 +81,7 @@ spec:
         if [ -z "$(params.dist-folder)" ]; then DIST_FOLDER="dist"; fi
 
         source_path=$(workspaces.source.path)/$(params.subdirectory)/$(params.path-context)
-
-        cp -r  $source_path/. /workspace
+        mv -fv $source_path /workspace
         cd /container_workspace
         bash universal_build.sh
 


### PR DESCRIPTION
The recursive copy resulted in the entire source tree being nested in the original source tree. This can actually break `webpack` in some cases.