### PR TITLE
chore: Bump frontend build container in create dockerfile task

### DIFF
--- a/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
+++ b/tasks/create-frontend-dockerfile/create-frontend-dockerfile.yaml
@@ -71,7 +71,7 @@ spec:
           memory: 2Gi
         limits:
           memory: 5Gi
-      image: quay.io/cloudservices/frontend-build-container:3bacc0b
+      image: quay.io/cloudservices/frontend-build-container:c99498b
       script: |
         #!/usr/bin/env sh
         set -xe


### PR DESCRIPTION
Caddy exception has been dropped here https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/5649

The previous tag is still using the old caddy image, whereas the latest tag is using the new image

## Summary by Sourcery

Chores:
- Bump the frontend build container image from tag 3bacc0b to c99498b